### PR TITLE
Disassociate existing instance profile & add AmazonSSMManagedInstance…

### DIFF
--- a/cf-templates/stack.yaml
+++ b/cf-templates/stack.yaml
@@ -778,6 +778,7 @@ Resources:
           - sts:AssumeRole
       ManagedPolicyArns:
       - arn:aws:iam::aws:policy/AdministratorAccess
+      - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
       Path: "/"
       Policies:
       - PolicyName:
@@ -829,6 +830,7 @@ Resources:
             - ec2:AssociateIamInstanceProfile
             - ec2:ModifyInstanceAttribute
             - ec2:ReplaceIamInstanceProfileAssociation
+            - ec2:DisassociateIamInstanceProfile
             Resource: !Sub "arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:instance/*"
           - Effect: Allow
             Action:
@@ -926,11 +928,20 @@ Resources:
                           time.sleep(5)
                           instance_state = ec2.describe_instances(InstanceIds=[instance['InstanceId']])
                           logger.info('instance_state: {}'.format(instance_state))
+                      
+                      # Disassociate existing IAM instance profile
+                      instance_profiles = ec2.describe_iam_instance_profile_associations()
+                      logger.info('instance_profiles: {}'.format(instance_profiles))
+                      for profile in instance_profiles['IamInstanceProfileAssociations']:
+                        if (profile['InstanceId'] == instance['InstanceId']) and profile['State'] == 'associated':
+                          logger.info(profile)
+                          disassociation = ec2.disassociate_iam_instance_profile(AssociationId=profile['AssociationId'])
+                          logger.info('Disassociated existing instance profile attached to the EC2 instance: {}'.format(disassociation))
+                          time.sleep(5)
           
                       # attach instance profile
                       response = ec2.associate_iam_instance_profile(IamInstanceProfile=iam_instance_profile, InstanceId=instance['InstanceId'])
                       logger.info('response - associate_iam_instance_profile: {}'.format(response))
-                      #r_ec2 = boto3.resource('ec2')
   
                       responseData = {'Success': 'Started bootstrapping for instance: '+instance['InstanceId']}
                       cfnresponse.send(event, context, cfnresponse.SUCCESS, responseData, 'CustomResourcePhysicalID')


### PR DESCRIPTION
…Core so that the instance doesn't violate AWS policy

*Issue #, if available:*
Cloud Formation fails to attach instance profile to Cloud9 instance.

*Description of changes:*
I've PVRE Reporting via Systems Manager configured. So it always attaches an instance profile automatically when a new instance is spinned up. The cfn used to fail as it again tries to attach an instance profile to Cloud9 instance which already has an instance profile attached. 

So as a solution, I'm first disassociating the existing instance profile from Cloud9 and then reattaching the new instance profile. Also in the new instance profile I've added the managed policy AmazonSSMManagedInstanceCore so that it doesn't violate the PVRE reporting.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
