### PR TITLE
feat: Added fluent-bit logs trought data-prepper

### DIFF
--- a/sample-apps/00-fluentBit/kubernetes/fluentbit.yaml
+++ b/sample-apps/00-fluentBit/kubernetes/fluentbit.yaml
@@ -81,18 +81,16 @@ data:
         K8S-Logging.Parser  On
         K8S-Logging.Exclude Off
 
-  output-elasticsearch.conf: |
+  output-data-prepper.conf: |
     [OUTPUT]
-        Name  es
+        Name  http
         Match *
-        Host  __AOS_ENDPOINT__
-        Port  443
-        Index sample_app_logs
-        Type  docker
-        HTTP_User __AOS_USERNAME__
-        HTTP_Passwd __AOS_PASSWORD__
-        tls On
+        Host  data-prepper.data-prepper.svc.cluster.local
+        Port  2021
+        tls Off
         tls.verify Off
+        Format json
+        URI /log/ingest
 
   parsers.conf: |
     [PARSER]

--- a/sample-apps/01-data-preper/kubernetes/data-preper.yaml
+++ b/sample-apps/01-data-preper/kubernetes/data-preper.yaml
@@ -47,6 +47,24 @@ data:
             username: "__AOS_USERNAME__"
             password: "__AOS_PASSWORD__"
             trace_analytics_service_map: true
+    log-pipeline:
+      source:
+        http:
+          ssl: false
+          authentication:
+            unauthenticated:
+      processor:
+        - grok:
+            match:
+              # This will match logs with a "log" key against the COMMONAPACHELOG pattern (ex: { "log": "actual apache log..." } )
+              # You should change this to match what your logs look like. See the grok documenation to get started.
+              log: [ "%{COMMONAPACHELOG}" ]
+      sink:
+        - opensearch:
+            hosts: [ "https://__AOS_ENDPOINT__" ]
+            username: "__AOS_USERNAME__"
+            password: "__AOS_PASSWORD__"
+            index: test_logs 
   data-prepper-config.yaml: |
     ssl: false
 ---
@@ -63,6 +81,9 @@ spec:
     - name: "21890"
       port: 21890
       targetPort: 21890
+    - name: "2021" # Port for http source communication
+      port: 2021
+      targetPort: 2021
   selector:
     app: data-prepper
 status:
@@ -116,6 +137,9 @@ spec:
           name: data-prepper
           ports:
             - containerPort: 21890
+              protocol: TCP
+            - containerPort: 2021 # Port for http source communication
+              protocol: TCP
           resources: {}
           volumeMounts:
             - mountPath: /etc/data-prepper


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Added support for fluent-bit send logs not directly to OpenSearch but to Data Prepper.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
