### PR TITLE
Feat/opensearch 1.3

### DIFF
--- a/cf-templates/stack.yaml
+++ b/cf-templates/stack.yaml
@@ -59,7 +59,7 @@ Parameters:
   EngineVersion:
     Description: Amazon OpenSearch Service - Version
     Type: String
-    Default: "OpenSearch_1.2"
+    Default: "OpenSearch_1.3"
   
   InstanceType:
     Description: Amazon OpenSearch Service - Instance Type

--- a/cf-templates/stack.yaml
+++ b/cf-templates/stack.yaml
@@ -883,7 +883,7 @@ Resources:
         Fn::GetAtt:
         - C9LambdaExecutionRole
         - Arn
-      Runtime: python3.6
+      Runtime: python3.9
       MemorySize: 256
       Timeout: 600
       Code:
@@ -1016,7 +1016,7 @@ Resources:
             - yum -y remove aws-cli; yum -y install sqlite telnet jq strace tree gcc glibc-static python3 python3-pip gettext bash-completion
             - echo '=== CONFIGURE default python version ==='
             - PATH=$PATH:/usr/bin
-            - alternatives --set python /usr/bin/python3.6
+            - alternatives --set python /usr/bin/python3.9
             - echo '=== INSTALL and CONFIGURE default software components ==='
             - sudo -H -u ec2-user bash -c "pip install --user -U boto boto3 botocore awscli aws-sam-cli"
             - echo '=== INSTALL Kubectl ==='


### PR DESCRIPTION
Updated to the new version of OpenSearch 1.3 and changed the Lambda runtime to Python 3.9 due to the new minimum version requirement.

Currently, EBS with GP2 has been maintained because it is not yet supported via CFN.