### PR TITLE
Changed image tag to stable

### DIFF
--- a/sample-apps/00-fluentBit/kubernetes/fluentbit.yaml
+++ b/sample-apps/00-fluentBit/kubernetes/fluentbit.yaml
@@ -182,7 +182,7 @@ spec:
     spec:
       containers:
       - name: fluent-bit
-        image: amazon/aws-for-fluent-bit:2.5.0
+        image: amazon/aws-for-fluent-bit:stable
         imagePullPolicy: Always
         ports:
           - containerPort: 2020


### PR DESCRIPTION
Changed the image tag to stable from Fluentbit due to a series of critical updates pending.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
