### PR TITLE
fix: defining role naming to avoid side-effects

### DIFF
--- a/cf-templates/opensearch.yaml
+++ b/cf-templates/opensearch.yaml
@@ -248,7 +248,7 @@ Resources:
   IAMRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub Linux-SSMRoletoEC2-${AWS::StackName}
+      RoleName: Linux-SSMRoletoEC2-OpenSearch-Workshop
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:


### PR DESCRIPTION
*Description of changes:*

While working on some iterations I got the following error that makes the Stack fail at creation:

```
1 validation error detected: Value 'Linux-SSMRoletoEC2-observability-with-amazon-opensearch-OpenSearch-114E9CRBKAPMT' at 'roleName' failed to satisfy constraint: Member must have length less than or equal to 64
```

The previous code generates the role name to `RoleName: !Sub Linux-SSMRoletoEC2-${AWS::StackName}` since the _Stack Name_ is defined for the users, and the Stack Name can be up to [`128` characters](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-using-console-create-stack-parameters.html), there's not a fail-safe to interpolate this string (or, at least, in my knowledge. Is possible to trim strings in CF at runtime?). Since _roles names_ should be less or equal to `64` this can lead to bad experiences in workshops. I'm changing to this hardcoded name: `Linux-SSMRoletoEC2-OpenSearch-Workshop`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
