### PR TITLE
Fix: correction of the deletion process (CFN)

### DIFF
--- a/cf-templates/base.yaml
+++ b/cf-templates/base.yaml
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: 2010-09-09
-Description: "This template creates the base resources for the Microservice Observability with Amazon OpenSearch Service Workshop."
+Description: "This template creates the Base resources for the Microservice Observability with Amazon OpenSearch Service Workshop."
 
 Parameters:
   VpcCIDR:
@@ -371,7 +371,7 @@ Resources:
     Properties:
       RepositoryName: "client-service"
 
-  ### Shared IAM Roles ###
+  ######## Shared IAM Roles ########
 
   AWSServiceRoleForAmazonOpenSearchService:
     Type: "AWS::IAM::ServiceLinkedRole"
@@ -402,13 +402,15 @@ Resources:
                   - "iam:PassRole"
                   - "iam:GetRole"
                   - "iam:DetachRolePolicy"
+                  - "iam:DeleteRole"
                   - "cloudformation:CreateStack"
                   - "cloudformation:CreateChangeSet"
                   - "cloudformation:DeleteStack"
                   - "cloudformation:DescribeStacks"
                   - "eks:DescribeCluster"
-                  - "eks:DeleteCluster"
                   - "eks:DescribeNodegroup"
+                  - "eks:DeleteCluster"
+                  - "eks:DeleteNodegroup"
                 Resource: "*"
 
   EKSIAMRole:

--- a/cf-templates/base.yaml
+++ b/cf-templates/base.yaml
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: 2010-09-09
-Description: "This template creates base resources for the Microservice Observability with Amazon OpenSearch Service Workshop."
+Description: "This template creates the base resources for the Microservice Observability with Amazon OpenSearch Service Workshop."
 
 Parameters:
   VpcCIDR:
@@ -25,7 +25,7 @@ Conditions:
   CreateNgwResource: !Equals [!Ref NatGateway, "Yes"]
 
 Resources:
-  ######## VPC ########
+  ######## Amazon VPC ########
   VPC:
     Type: AWS::EC2::VPC
     Properties:
@@ -330,7 +330,7 @@ Resources:
       ServiceName: !Sub com.amazonaws.${AWS::Region}.ec2messages
       VpcId: !Ref VPC
 
-  ######## ECR Repositories ########
+  ######## Amazon ECR Repositories ########
   AnalyticsServiceRepository:
     Type: AWS::ECR::Repository
     Properties:
@@ -401,11 +401,14 @@ Resources:
                   - "logs:PutLogEvents"
                   - "iam:PassRole"
                   - "iam:GetRole"
+                  - "iam:DetachRolePolicy"
                   - "cloudformation:CreateStack"
                   - "cloudformation:CreateChangeSet"
                   - "cloudformation:DeleteStack"
                   - "cloudformation:DescribeStacks"
                   - "eks:DescribeCluster"
+                  - "eks:DeleteCluster"
+                  - "eks:DescribeNodegroup"
                 Resource: "*"
 
   EKSIAMRole:

--- a/cf-templates/base.yaml
+++ b/cf-templates/base.yaml
@@ -1,7 +1,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: "This template creates base resources for the Microservice Observability with Amazon OpenSearch Service Workshop."
 
-Parameters: 
+Parameters:
   VpcCIDR:
     Type: String
   EnvironmentName:
@@ -21,11 +21,11 @@ Parameters:
   NatGateway:
     Type: String
 
-Conditions: 
-  CreateNgwResource: !Equals [ !Ref NatGateway, "Yes" ]
+Conditions:
+  CreateNgwResource: !Equals [!Ref NatGateway, "Yes"]
 
-Resources: 
-######## VPC ########
+Resources:
+  ######## VPC ########
   VPC:
     Type: AWS::EC2::VPC
     Properties:
@@ -55,7 +55,7 @@ Resources:
     Type: AWS::EC2::Subnet
     Properties:
       VpcId: !Ref VPC
-      AvailabilityZone: !Select [ 0, !GetAZs '' ]
+      AvailabilityZone: !Select [0, !GetAZs ""]
       CidrBlock: !Ref PublicSubnet1CIDR
       MapPublicIpOnLaunch: true
       Tags:
@@ -66,7 +66,7 @@ Resources:
     Type: AWS::EC2::Subnet
     Properties:
       VpcId: !Ref VPC
-      AvailabilityZone: !Select [ 1, !GetAZs  '' ]
+      AvailabilityZone: !Select [1, !GetAZs ""]
       CidrBlock: !Ref PublicSubnet2CIDR
       MapPublicIpOnLaunch: true
       Tags:
@@ -77,7 +77,7 @@ Resources:
     Type: AWS::EC2::Subnet
     Properties:
       VpcId: !Ref VPC
-      AvailabilityZone: !Select [ 2, !GetAZs  '' ]
+      AvailabilityZone: !Select [2, !GetAZs ""]
       CidrBlock: !Ref PublicSubnet3CIDR
       MapPublicIpOnLaunch: true
       Tags:
@@ -88,7 +88,7 @@ Resources:
     Type: AWS::EC2::Subnet
     Properties:
       VpcId: !Ref VPC
-      AvailabilityZone: !Select [ 0, !GetAZs  '' ]
+      AvailabilityZone: !Select [0, !GetAZs ""]
       CidrBlock: !Ref PrivateSubnet1CIDR
       MapPublicIpOnLaunch: false
       Tags:
@@ -101,7 +101,7 @@ Resources:
     Type: AWS::EC2::Subnet
     Properties:
       VpcId: !Ref VPC
-      AvailabilityZone: !Select [ 1, !GetAZs  '' ]
+      AvailabilityZone: !Select [1, !GetAZs ""]
       CidrBlock: !Ref PrivateSubnet2CIDR
       MapPublicIpOnLaunch: false
       Tags:
@@ -114,7 +114,7 @@ Resources:
     Type: AWS::EC2::Subnet
     Properties:
       VpcId: !Ref VPC
-      AvailabilityZone: !Select [ 2, !GetAZs  '' ]
+      AvailabilityZone: !Select [2, !GetAZs ""]
       CidrBlock: !Ref PrivateSubnet3CIDR
       MapPublicIpOnLaunch: false
       Tags:
@@ -287,7 +287,7 @@ Resources:
         - Description: Allow all outbound traffic
           IpProtocol: "-1"
           CidrIp: 0.0.0.0/0
-      
+
   CreateVpcEndpointSSM:
     Type: AWS::EC2::VPCEndpoint
     Properties:
@@ -330,7 +330,7 @@ Resources:
       ServiceName: !Sub com.amazonaws.${AWS::Region}.ec2messages
       VpcId: !Ref VPC
 
-######## ECR Repositories ########
+  ######## ECR Repositories ########
   AnalyticsServiceRepository:
     Type: AWS::ECR::Repository
     Properties:
@@ -344,22 +344,22 @@ Resources:
   OrderServiceRepository:
     Type: AWS::ECR::Repository
     Properties:
-      RepositoryName: "order-service"     
+      RepositoryName: "order-service"
 
   InventoryServiceRepository:
     Type: AWS::ECR::Repository
     Properties:
-      RepositoryName: "inventory-service"            
+      RepositoryName: "inventory-service"
 
   PaymentServiceRepository:
     Type: AWS::ECR::Repository
     Properties:
-      RepositoryName: "payment-service"        
+      RepositoryName: "payment-service"
 
   RecommendationServiceRepository:
     Type: AWS::ECR::Repository
     Properties:
-      RepositoryName: "recommendation-service"        
+      RepositoryName: "recommendation-service"
 
   AuthenticationServiceRepository:
     Type: AWS::ECR::Repository
@@ -371,7 +371,12 @@ Resources:
     Properties:
       RepositoryName: "client-service"
 
-### Shared IAM Roles ###
+  ### Shared IAM Roles ###
+
+  AWSServiceRoleForAmazonOpenSearchService:
+    Type: "AWS::IAM::ServiceLinkedRole"
+    Properties:
+      AWSServiceName: opensearchservice.amazonaws.com
 
   DeployCloudformationStackLambdaRole:
     Type: AWS::IAM::Role
@@ -391,31 +396,33 @@ Resources:
             Statement:
               - Effect: Allow
                 Action:
-                  - 'logs:CreateLogGroup'
-                  - 'logs:CreateLogStream'
-                  - 'logs:PutLogEvents'
-                  - 'iam:PassRole'
-                  - 'iam:GetRole'
-                  - 'cloudformation:CreateStack'
-                  - 'cloudformation:CreateChangeSet'
-                  - 'eks:DescribeCluster'
-                Resource: '*'
+                  - "logs:CreateLogGroup"
+                  - "logs:CreateLogStream"
+                  - "logs:PutLogEvents"
+                  - "iam:PassRole"
+                  - "iam:GetRole"
+                  - "cloudformation:CreateStack"
+                  - "cloudformation:CreateChangeSet"
+                  - "cloudformation:DeleteStack"
+                  - "cloudformation:DescribeStacks"
+                  - "eks:DescribeCluster"
+                Resource: "*"
 
   EKSIAMRole:
-    Type: 'AWS::IAM::Role'
+    Type: "AWS::IAM::Role"
     Properties:
       AssumeRolePolicyDocument:
         Version: 2012-10-17
-        Statement:  
+        Statement:
           - Effect: Allow
             Principal:
               Service:
-                - eks.amazonaws.com       
+                - eks.amazonaws.com
             Action:
-              - 'sts:AssumeRole'
+              - "sts:AssumeRole"
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/AmazonEKSClusterPolicy
-        - arn:aws:iam::aws:policy/AmazonEKSServicePolicy   
+        - arn:aws:iam::aws:policy/AmazonEKSServicePolicy
 
 Outputs:
   VPC:

--- a/cf-templates/cloud9.yaml
+++ b/cf-templates/cloud9.yaml
@@ -1,7 +1,7 @@
 AWSTemplateFormatVersion: 2010-09-09
-Description: "Template to create the Cloud9 resources on the Microservice Observability with Amazon OpenSearch Service Workshop."
+Description: "This template create the AWS Cloud9 resources for the Microservice Observability with Amazon OpenSearch Service Workshop."
 
-Parameters: 
+Parameters:
   EnvironmentNameC9:
     Type: String
   C9InstanceType:
@@ -19,13 +19,13 @@ Parameters:
   EKSIAMRole:
     Type: String
 
-Conditions: 
-  Create3rdPartyResources: !Equals [ !Ref C9EnvType, 3rdParty ]
-  CreateEventEngineResources: !Equals [ !Ref C9EnvType, event-engine ]
-  CreateWorkstudioResources: !Equals [ !Ref C9EnvType, workshop-studio ]
+Conditions:
+  Create3rdPartyResources: !Equals [!Ref C9EnvType, 3rdParty]
+  CreateEventEngineResources: !Equals [!Ref C9EnvType, event-engine]
+  CreateWorkstudioResources: !Equals [!Ref C9EnvType, workshop-studio]
 
-Resources: 
-######## Cloud9 ########
+Resources:
+  ######## AWS Cloud9 ########
   C9Role:
     Type: AWS::IAM::Role
     Properties:
@@ -34,136 +34,136 @@ Resources:
         - Key: Environment
           Value: !Sub ${EnvironmentNameC9}
       AssumeRolePolicyDocument:
-        Version: '2012-10-17'
+        Version: "2012-10-17"
         Statement:
-        - Effect: Allow
-          Principal:
-            Service:
-            - ec2.amazonaws.com
-            - ssm.amazonaws.com
-            - eks.amazonaws.com
-            - codebuild.amazonaws.com
-          Action:
-          - sts:AssumeRole
-        - Effect: Allow
-          Principal:
-            AWS: !Ref DeployCloudformationStackLambdaRole
-          Action: sts:AssumeRole
+          - Effect: Allow
+            Principal:
+              Service:
+                - ec2.amazonaws.com
+                - ssm.amazonaws.com
+                - eks.amazonaws.com
+                - codebuild.amazonaws.com
+            Action:
+              - sts:AssumeRole
+          - Effect: Allow
+            Principal:
+              AWS: !Ref DeployCloudformationStackLambdaRole
+            Action: sts:AssumeRole
       ManagedPolicyArns:
-      - arn:aws:iam::aws:policy/AdministratorAccess
-      - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+        - arn:aws:iam::aws:policy/AdministratorAccess
+        - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
       Path: "/"
       Policies:
-      - PolicyName:
-          Fn::Join:
-          - ''
-          - - C9InstanceDenyPolicy-
-            - Ref: AWS::Region
-        PolicyDocument:
-          Version: '2012-10-17'
-          Statement:
-          - Effect: Deny
-            Action:
-            - cloud9:UpdateEnvironment
-            Resource: "*"
-      - PolicyName: RunKubeCtlCommands
-        PolicyDocument:
-          Version: 2012-10-17
-          Statement:
-          - Effect: Allow
-            Action:
-              - 'eks:*'
-              - 'cloudformation:CreateStack'
-              - 'cloudformation:CreateChangeSet'
-              - 'serverlessrepo:CreateCloudFormationTemplate'
-              - 'serverlessrepo:GetCloudFormationTemplate'
-              - 's3:GetObject'
-              - 'lambda:PublishLayerVersion'
-              - 'lambda:CreateFunction'
-              - 'lambda:GetLayerVersion'
-              - 'lambda:GetFunction'
-              - 'lambda:InvokeFunction'
-              - 'lambda:GetFunctionConfiguration'
-              - 'iam:PassRole'
-              - 'iam:GetRole'
-              - 'logs:CreateLogGroup'
-              - 'logs:CreateLogStream'
-              - 'logs:PutLogEvents'
-            Resource: '*'
-          - Effect: Allow
-            Action:
-              - 'iam:PassRole'
-              - 'iam:GetRole'
-            Resource: 
-              - !Ref EKSIAMRole
-              - !Ref DeployCloudformationStackLambdaRole
+        - PolicyName:
+            Fn::Join:
+              - ""
+              - - C9InstanceDenyPolicy-
+                - Ref: AWS::Region
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Deny
+                Action:
+                  - cloud9:UpdateEnvironment
+                Resource: "*"
+        - PolicyName: RunKubeCtlCommands
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - "eks:*"
+                  - "cloudformation:CreateStack"
+                  - "cloudformation:CreateChangeSet"
+                  - "serverlessrepo:CreateCloudFormationTemplate"
+                  - "serverlessrepo:GetCloudFormationTemplate"
+                  - "s3:GetObject"
+                  - "lambda:PublishLayerVersion"
+                  - "lambda:CreateFunction"
+                  - "lambda:GetLayerVersion"
+                  - "lambda:GetFunction"
+                  - "lambda:InvokeFunction"
+                  - "lambda:GetFunctionConfiguration"
+                  - "iam:PassRole"
+                  - "iam:GetRole"
+                  - "logs:CreateLogGroup"
+                  - "logs:CreateLogStream"
+                  - "logs:PutLogEvents"
+                Resource: "*"
+              - Effect: Allow
+                Action:
+                  - "iam:PassRole"
+                  - "iam:GetRole"
+                Resource:
+                  - !Ref EKSIAMRole
+                  - !Ref DeployCloudformationStackLambdaRole
 
   C9LambdaExecutionRole:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
-        Version: '2012-10-17'
+        Version: "2012-10-17"
         Statement:
-        - Effect: Allow
-          Principal:
-            Service:
-            - lambda.amazonaws.com
-          Action:
-          - sts:AssumeRole
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - sts:AssumeRole
       Path: "/"
       ManagedPolicyArns:
         - "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
       Policies:
-      - PolicyName:
-          Fn::Join:
-          - ''
-          - - C9LambdaPolicy-
-            - Ref: AWS::Region
-        PolicyDocument:
-          Version: '2012-10-17'
-          Statement:
-          - Effect: Allow
-            Action:
-            - cloudformation:DescribeStacks
-            - cloudformation:DescribeStackEvents
-            - cloudformation:DescribeStackResource
-            - cloudformation:DescribeStackResources
-            Resource: !Sub "arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/*"
-          - Effect: Allow
-            Action:
-            - ec2:AssociateIamInstanceProfile
-            - ec2:ModifyInstanceAttribute
-            - ec2:ReplaceIamInstanceProfileAssociation
-            - ec2:DisassociateIamInstanceProfile
-            Resource: !Sub "arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:instance/*"
-          - Effect: Allow
-            Action:
-            - ec2:DescribeInstances
-            - ec2:DescribeIamInstanceProfileAssociations
-            Resource: "*"         
-          - Effect: Allow
-            Action:
-            - iam:ListInstanceProfiles
-            Resource: !Sub arn:aws:iam::${AWS::AccountId}:instance-profile/*
-          - Effect: Allow
-            Action:
-            - iam:PassRole
-            Resource: 
-              Fn::GetAtt:
-                - C9Role
-                - Arn
+        - PolicyName:
+            Fn::Join:
+              - ""
+              - - C9LambdaPolicy-
+                - Ref: AWS::Region
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - cloudformation:DescribeStacks
+                  - cloudformation:DescribeStackEvents
+                  - cloudformation:DescribeStackResource
+                  - cloudformation:DescribeStackResources
+                Resource: !Sub "arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/*"
+              - Effect: Allow
+                Action:
+                  - ec2:AssociateIamInstanceProfile
+                  - ec2:ModifyInstanceAttribute
+                  - ec2:ReplaceIamInstanceProfileAssociation
+                  - ec2:DisassociateIamInstanceProfile
+                Resource: !Sub "arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:instance/*"
+              - Effect: Allow
+                Action:
+                  - ec2:DescribeInstances
+                  - ec2:DescribeIamInstanceProfileAssociations
+                Resource: "*"
+              - Effect: Allow
+                Action:
+                  - iam:ListInstanceProfiles
+                Resource: !Sub arn:aws:iam::${AWS::AccountId}:instance-profile/*
+              - Effect: Allow
+                Action:
+                  - iam:PassRole
+                Resource:
+                  Fn::GetAtt:
+                    - C9Role
+                    - Arn
   C9BootstrapInstanceLambda:
     Type: Custom::C9BootstrapInstanceLambda
     DependsOn:
-    - C9LambdaExecutionRole
+      - C9LambdaExecutionRole
     Properties:
       Tags:
         - Key: Environment
           Value: !Sub ${EnvironmentNameC9}
       ServiceToken:
         Fn::GetAtt:
-        - C9BootstrapInstanceLambdaFunction
-        - Arn
+          - C9BootstrapInstanceLambdaFunction
+          - Arn
       REGION:
         Ref: AWS::Region
       StackName:
@@ -174,8 +174,8 @@ Resources:
         Ref: C9InstanceProfile
       LabIdeInstanceProfileArn:
         Fn::GetAtt:
-        - C9InstanceProfile
-        - Arn
+          - C9InstanceProfile
+          - Arn
   C9BootstrapInstanceLambdaFunction:
     Type: AWS::Lambda::Function
     Properties:
@@ -185,8 +185,8 @@ Resources:
       Handler: index.lambda_handler
       Role:
         Fn::GetAtt:
-        - C9LambdaExecutionRole
-        - Arn
+          - C9LambdaExecutionRole
+          - Arn
       Runtime: python3.9
       MemorySize: 256
       Timeout: 600
@@ -203,28 +203,28 @@ Resources:
 
           logger = logging.getLogger(__name__)
           logger.setLevel(logging.INFO)
-          
+
           def lambda_handler(event, context):
               logger.info('event: {}'.format(event))
               logger.info('context: {}'.format(context))
               responseData = {}
-          
+
               if event['RequestType'] == 'Create':
                   try:
                       # Open AWS clients
                       ec2 = boto3.client('ec2')
-          
+
                       # Get the InstanceId of the Cloud9 IDE
                       instance = ec2.describe_instances(Filters=[{'Name': 'tag:Name','Values': ['aws-cloud9-observabilityworkshop'+'-'+event['ResourceProperties']['EnvironmentId']]}])['Reservations'][0]['Instances'][0]
                       logger.info('instance: {}'.format(instance))
-          
+
                       # Create the IamInstanceProfile request object
                       iam_instance_profile = {
                           'Arn': event['ResourceProperties']['LabIdeInstanceProfileArn'],
                           'Name': event['ResourceProperties']['LabIdeInstanceProfileName']
                       }
                       logger.info('iam_instance_profile: {}'.format(iam_instance_profile))
-          
+
                       # Wait for Instance to become ready before adding Role
                       instance_state = instance['State']['Name']
                       logger.info('instance_state: {}'.format(instance_state))
@@ -242,11 +242,11 @@ Resources:
                           disassociation = ec2.disassociate_iam_instance_profile(AssociationId=profile['AssociationId'])
                           logger.info('Disassociated existing instance profile attached to the EC2 instance: {}'.format(disassociation))
                           time.sleep(5)
-          
+
                       # attach instance profile
                       response = ec2.associate_iam_instance_profile(IamInstanceProfile=iam_instance_profile, InstanceId=instance['InstanceId'])
                       logger.info('response - associate_iam_instance_profile: {}'.format(response))
-  
+
                       responseData = {'Success': 'Started bootstrapping for instance: '+instance['InstanceId']}
                       cfnresponse.send(event, context, cfnresponse.SUCCESS, responseData, 'CustomResourcePhysicalID')
                       
@@ -259,7 +259,7 @@ Resources:
               else:
                 responseData = {'Success': 'Update or delete event'}
                 cfnresponse.send(event, context, cfnresponse.SUCCESS, responseData, 'CustomResourcePhysicalID')
-################## SSM BOOTSRAP HANDLER ###############
+  ################## SSM BOOTSRAP HANDLER ###############
   C9OutputBucket:
     Type: AWS::S3::Bucket
     DeletionPolicy: Retain
@@ -283,121 +283,121 @@ Resources:
         Version: 2012-10-17
         Statement:
           - Action:
-              - 's3:GetObject'
-              - 's3:PutObject'
-              - 's3:PutObjectAcl'
+              - "s3:GetObject"
+              - "s3:PutObject"
+              - "s3:PutObjectAcl"
             Effect: Allow
             Resource: !Join
-              - ''
-              - - 'arn:aws:s3:::'
+              - ""
+              - - "arn:aws:s3:::"
                 - !Ref C9OutputBucket
                 - /*
             Principal:
-              AWS: 
+              AWS:
                 Fn::GetAtt:
-                - C9LambdaExecutionRole
-                - Arn
-  C9SSMDocument: 
+                  - C9LambdaExecutionRole
+                  - Arn
+  C9SSMDocument:
     Type: AWS::SSM::Document
-    Properties: 
+    Properties:
       Tags:
         - Key: Environment
           Value: !Sub ${EnvironmentNameC9}
       DocumentType: Command
-      Content: 
-        schemaVersion: '2.2'
+      Content:
+        schemaVersion: "2.2"
         description: Bootstrap Cloud9 Instance
         mainSteps:
-        - action: aws:runShellScript
-          name: C9bootstrap
-          inputs:
-            runCommand:
-            - "#!/bin/bash"
-            - date
-            - echo LANG=en_US.utf-8 >> /etc/environment
-            - echo LC_ALL=en_US.UTF-8 >> /etc/environment
-            - . /home/ec2-user/.bashrc
-            - yum -y remove aws-cli; yum -y install sqlite telnet jq strace tree gcc glibc-static python3 python3-pip gettext bash-completion
-            - echo '=== CONFIGURE default python version ==='
-            - PATH=$PATH:/usr/bin
-            - alternatives --set python /usr/bin/python3.9
-            - echo '=== INSTALL and CONFIGURE default software components ==='
-            - sudo -H -u ec2-user bash -c "pip install --user -U boto boto3 botocore awscli aws-sam-cli"
-            - echo '=== INSTALL Kubectl ==='
-            - curl -o kubectl https://s3.us-west-2.amazonaws.com/amazon-eks/1.21.2/2021-07-05/bin/linux/amd64/kubectl
-            - sudo chmod +x kubectl && sudo mv kubectl /usr/local/bin/
-            - sudo echo "source <(kubectl completion bash)" >> ~/.bashrc
-            - echo '=== INSTALL eksctl ==='
-            - curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
-            - sudo mv /tmp/eksctl /usr/local/bin
-            - echo '=== Resizing the Instance volume'
-            - !Sub SIZE=${C9InstanceVolumeSize}
-            - !Sub REGION=${AWS::Region}
-            - |
-              TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
-              INSTANCEID=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/instance-id)
-              VOLUMEID=$(aws ec2 describe-instances \
-                --instance-id $INSTANCEID \
-                --query "Reservations[0].Instances[0].BlockDeviceMappings[0].Ebs.VolumeId" \
-                --output text --region $REGION)
-              aws ec2 modify-volume --volume-id $VOLUMEID --size $SIZE --region $REGION
-              while [ \
-                "$(aws ec2 describe-volumes-modifications \
-                  --volume-id $VOLUMEID \
-                  --filters Name=modification-state,Values="optimizing","completed" \
-                  --query "length(VolumesModifications)"\
-                  --output text --region $REGION)" != "1" ]; do
-              sleep 1
-              done
-              if [ $(readlink -f /dev/xvda) = "/dev/xvda" ]
-              then
-                sudo growpart /dev/xvda 1
-                STR=$(cat /etc/os-release)
-                SUB="VERSION_ID=\"2\""
-                if [[ "$STR" == *"$SUB"* ]]
-                then
-                  sudo xfs_growfs -d /
-                else
-                  sudo resize2fs /dev/xvda1
-                fi
-              else
-                sudo growpart /dev/nvme0n1 1
-                STR=$(cat /etc/os-release)
-                SUB="VERSION_ID=\"2\""
-                if [[ "$STR" == *"$SUB"* ]]
-                then
-                  sudo xfs_growfs -d /
-                else
-                  sudo resize2fs /dev/nvme0n1p1
-                fi
-              fi
-            - echo "Bootstrap completed with return code $?"
+          - action: aws:runShellScript
+            name: C9bootstrap
+            inputs:
+              runCommand:
+                - "#!/bin/bash"
+                - date
+                - echo LANG=en_US.utf-8 >> /etc/environment
+                - echo LC_ALL=en_US.UTF-8 >> /etc/environment
+                - . /home/ec2-user/.bashrc
+                - yum -y remove aws-cli; yum -y install sqlite telnet jq strace tree gcc glibc-static python3 python3-pip gettext bash-completion
+                - echo '=== CONFIGURE default python version ==='
+                - PATH=$PATH:/usr/bin
+                - alternatives --set python /usr/bin/python3.9
+                - echo '=== INSTALL and CONFIGURE default software components ==='
+                - sudo -H -u ec2-user bash -c "pip install --user -U boto boto3 botocore awscli aws-sam-cli"
+                - echo '=== INSTALL Kubectl ==='
+                - curl -o kubectl https://s3.us-west-2.amazonaws.com/amazon-eks/1.21.2/2021-07-05/bin/linux/amd64/kubectl
+                - sudo chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+                - sudo echo "source <(kubectl completion bash)" >> ~/.bashrc
+                - echo '=== INSTALL eksctl ==='
+                - curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
+                - sudo mv /tmp/eksctl /usr/local/bin
+                - echo '=== Resizing the Instance volume'
+                - !Sub SIZE=${C9InstanceVolumeSize}
+                - !Sub REGION=${AWS::Region}
+                - |
+                  TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
+                  INSTANCEID=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/instance-id)
+                  VOLUMEID=$(aws ec2 describe-instances \
+                    --instance-id $INSTANCEID \
+                    --query "Reservations[0].Instances[0].BlockDeviceMappings[0].Ebs.VolumeId" \
+                    --output text --region $REGION)
+                  aws ec2 modify-volume --volume-id $VOLUMEID --size $SIZE --region $REGION
+                  while [ \
+                    "$(aws ec2 describe-volumes-modifications \
+                      --volume-id $VOLUMEID \
+                      --filters Name=modification-state,Values="optimizing","completed" \
+                      --query "length(VolumesModifications)"\
+                      --output text --region $REGION)" != "1" ]; do
+                  sleep 1
+                  done
+                  if [ $(readlink -f /dev/xvda) = "/dev/xvda" ]
+                  then
+                    sudo growpart /dev/xvda 1
+                    STR=$(cat /etc/os-release)
+                    SUB="VERSION_ID=\"2\""
+                    if [[ "$STR" == *"$SUB"* ]]
+                    then
+                      sudo xfs_growfs -d /
+                    else
+                      sudo resize2fs /dev/xvda1
+                    fi
+                  else
+                    sudo growpart /dev/nvme0n1 1
+                    STR=$(cat /etc/os-release)
+                    SUB="VERSION_ID=\"2\""
+                    if [[ "$STR" == *"$SUB"* ]]
+                    then
+                      sudo xfs_growfs -d /
+                    else
+                      sudo resize2fs /dev/nvme0n1p1
+                    fi
+                  fi
+                - echo "Bootstrap completed with return code $?"
 
-  C9BootstrapAssociation: 
+  C9BootstrapAssociation:
     Type: AWS::SSM::Association
-    Properties: 
+    Properties:
       Name: !Ref C9SSMDocument
-      OutputLocation: 
+      OutputLocation:
         S3Location:
           OutputS3BucketName: !Ref C9OutputBucket
           OutputS3KeyPrefix: bootstrapoutput
       Targets:
         - Key: tag:SSMBootstrap
           Values:
-          - Active
-  
+            - Active
+
   C9InstanceProfile:
     Type: AWS::IAM::InstanceProfile
     Properties:
       Path: "/"
       Roles:
-      - Ref: C9Role
+        - Ref: C9Role
 
   C9Instance:
     DependsOn: C9BootstrapAssociation
     Type: AWS::Cloud9::EnvironmentEC2
     Properties:
-      Description: !Sub  AWS Cloud9 instance for ${EnvironmentNameC9}
+      Description: !Sub AWS Cloud9 instance for ${EnvironmentNameC9}
       SubnetId: !Ref PublicSubnet1
       #ConnectionType: CONNECT_SSM
 
@@ -405,12 +405,39 @@ Resources:
       InstanceType:
         Ref: C9InstanceType
       Name: observabilityworkshop
-      OwnerArn: !If [Create3rdPartyResources, !Ref OwnerArn, !If [CreateEventEngineResources, !Join ['',['arn:aws:iam::',!Ref 'AWS::AccountId',':assumed-role/TeamRole/MasterKey']],!If [CreateWorkstudioResources, !Join ['',['arn:aws:iam::',!Ref 'AWS::AccountId',':assumed-role/WSParticipantRole/Participant']],!Ref "AWS::NoValue"]]]
-      Tags: 
+      OwnerArn:
+        !If [
+          Create3rdPartyResources,
+          !Ref OwnerArn,
+          !If [
+            CreateEventEngineResources,
+            !Join [
+              "",
+              [
+                "arn:aws:iam::",
+                !Ref "AWS::AccountId",
+                ":assumed-role/TeamRole/MasterKey",
+              ],
+            ],
+            !If [
+              CreateWorkstudioResources,
+              !Join [
+                "",
+                [
+                  "arn:aws:iam::",
+                  !Ref "AWS::AccountId",
+                  ":assumed-role/WSParticipantRole/Participant",
+                ],
+              ],
+              !Ref "AWS::NoValue",
+            ],
+          ],
+        ]
+      Tags:
         - Key: SSMBootstrap
           Value: Active
         - Key: Environment
-          Value: !Sub ${EnvironmentNameC9} 
+          Value: !Sub ${EnvironmentNameC9}
 
 Outputs:
   C9Role:
@@ -418,12 +445,12 @@ Outputs:
   Cloud9IDE:
     Value:
       Fn::Join:
-      - ''
-      - - https://
-        - Ref: AWS::Region
-        - ".console.aws.amazon.com/cloud9/ide/"
-        - Ref: C9Instance
-        - "?region="
-        - Ref: AWS::Region
+        - ""
+        - - https://
+          - Ref: AWS::Region
+          - ".console.aws.amazon.com/cloud9/ide/"
+          - Ref: C9Instance
+          - "?region="
+          - Ref: AWS::Region
     Export:
       Name: Cloud9IDE

--- a/cf-templates/cloud9.yaml
+++ b/cf-templates/cloud9.yaml
@@ -259,7 +259,7 @@ Resources:
               else:
                 responseData = {'Success': 'Update or delete event'}
                 cfnresponse.send(event, context, cfnresponse.SUCCESS, responseData, 'CustomResourcePhysicalID')
-  ################## SSM BOOTSRAP HANDLER ###############
+  ######## SSM BOOTSRAP HANDLER ########
   C9OutputBucket:
     Type: AWS::S3::Bucket
     DeletionPolicy: Retain

--- a/cf-templates/eks.yaml
+++ b/cf-templates/eks.yaml
@@ -1,5 +1,7 @@
 AWSTemplateFormatVersion: 2010-09-09
-Transform: 'AWS::Serverless-2016-10-31'
+Description: "This template create the EKS node group resources for the Microservice Observability with Amazon OpenSearch Service Workshop."
+
+Transform: "AWS::Serverless-2016-10-31"
 Parameters:
   EksClusterRole:
     Default: arn:*
@@ -27,20 +29,19 @@ Parameters:
     Type: String
 
 Resources:
-
   EKSNodesIAMRole:
-    Type: 'AWS::IAM::Role'
+    Type: "AWS::IAM::Role"
     Properties:
       AssumeRolePolicyDocument:
         Version: 2012-10-17
-        Statement:  
+        Statement:
           - Effect: Allow
             Principal:
               Service:
                 - eks.amazonaws.com
-                - ec2.amazonaws.com      
+                - ec2.amazonaws.com
             Action:
-              - 'sts:AssumeRole'
+              - "sts:AssumeRole"
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy
         - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly
@@ -49,19 +50,19 @@ Resources:
         - arn:aws:iam::aws:policy/ElasticLoadBalancingFullAccess
 
   EKS:
-    Type: 'AWS::EKS::Cluster'
+    Type: "AWS::EKS::Cluster"
     Properties:
       Name: !Ref EksClusterName
-      Version: '1.22'
+      Version: "1.22"
       RoleArn: !Ref EksClusterRole
       ResourcesVpcConfig:
         SubnetIds:
-         - !Ref EksSubnet1
-         - !Ref EksSubnet2
-         - !Ref EksSubnet3
-  
+          - !Ref EksSubnet1
+          - !Ref EksSubnet2
+          - !Ref EksSubnet3
+
   EKSNodegroup:
-    Type: 'AWS::EKS::Nodegroup'
+    Type: "AWS::EKS::Nodegroup"
     DependsOn: EKS
     Properties:
       ClusterName: !Ref EksClusterName

--- a/cf-templates/eks.yaml
+++ b/cf-templates/eks.yaml
@@ -53,7 +53,7 @@ Resources:
     Type: "AWS::EKS::Cluster"
     Properties:
       Name: !Ref EksClusterName
-      Version: "1.22"
+      Version: "1.23"
       RoleArn: !Ref EksClusterRole
       ResourcesVpcConfig:
         SubnetIds:

--- a/cf-templates/ekscluster.yaml
+++ b/cf-templates/ekscluster.yaml
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: 2010-09-09
-Description: "Template to create the EKS Clsuter resources on the Microservice Observability with Amazon OpenSearch Service Workshop."
+Description: "This template create the EKS Cluster resources for the Microservice Observability with Amazon OpenSearch Service Workshop."
 
 Parameters:
   EKSClusterName:

--- a/cf-templates/ekscluster.yaml
+++ b/cf-templates/ekscluster.yaml
@@ -64,7 +64,7 @@ Resources:
     Properties:
       Description: Deploy cloudformation stack
       Handler: index.lambda_handler
-      Runtime: python3.8
+      Runtime: python3.9
       Role: !Ref DeployCloudformationStackLambdaRole
       MemorySize: 128
       Timeout: 30

--- a/cf-templates/ekscluster.yaml
+++ b/cf-templates/ekscluster.yaml
@@ -1,7 +1,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: "Template to create the EKS Clsuter resources on the Microservice Observability with Amazon OpenSearch Service Workshop."
 
-Parameters: 
+Parameters:
   EKSClusterName:
     Type: String
   S3BucketName:
@@ -27,7 +27,7 @@ Parameters:
   DeployCloudformationStackLambdaRole:
     Type: String
 
-Resources: 
+Resources:
   ClusterControlPlaneSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
@@ -35,29 +35,29 @@ Resources:
       VpcId: !Ref VPC
 
   TriggerStack:
-      Type: "Custom::TriggerStack"
-      Properties:
-        ServiceToken: !GetAtt DeployCloudformationStack.Arn
-        cfStackName: "eksDeploy"
-        assumeRoleARN: !Ref C9Role
-        templateUrl: !Sub https://${S3BucketName}.s3.amazonaws.com/assets/eks.yaml
-        stackParameters: 
-          - ParameterKey: EksClusterName
-            ParameterValue: !Ref EKSClusterName
-          - ParameterKey: EksClusterRole
-            ParameterValue: !Ref EKSIAMRole
-          - ParameterKey: EksSubnet1
-            ParameterValue: !Ref PublicSubnet1
-          - ParameterKey: EksSubnet2
-            ParameterValue: !Ref PublicSubnet2
-          - ParameterKey: EksSubnet3
-            ParameterValue: !Ref PublicSubnet3
-          - ParameterKey: EksNodeSubnet1
-            ParameterValue: !Ref PrivateSubnet1
-          - ParameterKey: EksNodeSubnet2
-            ParameterValue: !Ref PrivateSubnet2
-          - ParameterKey: EksNodeSubnet3
-            ParameterValue: !Ref PrivateSubnet3
+    Type: "Custom::TriggerStack"
+    Properties:
+      ServiceToken: !GetAtt DeployCloudformationStack.Arn
+      cfStackName: "eksDeploy"
+      assumeRoleARN: !Ref C9Role
+      templateUrl: !Sub https://${S3BucketName}.s3.amazonaws.com/assets/eks.yaml
+      stackParameters:
+        - ParameterKey: EksClusterName
+          ParameterValue: !Ref EKSClusterName
+        - ParameterKey: EksClusterRole
+          ParameterValue: !Ref EKSIAMRole
+        - ParameterKey: EksSubnet1
+          ParameterValue: !Ref PublicSubnet1
+        - ParameterKey: EksSubnet2
+          ParameterValue: !Ref PublicSubnet2
+        - ParameterKey: EksSubnet3
+          ParameterValue: !Ref PublicSubnet3
+        - ParameterKey: EksNodeSubnet1
+          ParameterValue: !Ref PrivateSubnet1
+        - ParameterKey: EksNodeSubnet2
+          ParameterValue: !Ref PrivateSubnet2
+        - ParameterKey: EksNodeSubnet3
+          ParameterValue: !Ref PrivateSubnet3
 
   DeployCloudformationStack:
     Type: AWS::Lambda::Function
@@ -91,7 +91,7 @@ Resources:
              logger.error('Error: %s', e)
              result = cfnresponse.FAILED   
             cfnresponse.send(event, context, result, payload)
-          
+
           def deployStack(input):
               
               sts = boto3.client('sts').assume_role(RoleArn=input['assumeRoleARN'],RoleSessionName="lambda_assume_role")

--- a/cf-templates/main.yaml
+++ b/cf-templates/main.yaml
@@ -1,9 +1,9 @@
 AWSTemplateFormatVersion: 2010-09-09
 
-Description: This template deploys a VPC, with a pair of public and private subnets spread across three Availability Zones. In addition to the network components, the following will also be created (AWS Cloud9, Amazon OpenSearch Service and Reverse-Proxy Instance).
+Description: This template deploys a VPC, with a pair of public and private subnets spread across three Availability Zones. In addition to the network components, the following will also be created (AWS Cloud9, Amazon ECR, Amazon EKS, Amazon OpenSearch Service and Reverse-Proxy Instance).
 
 Parameters:
-  # VPC Variables
+  ######## VPC Variables ########
   EnvironmentName:
     Description: An environment name that is prefixed to resource names
     Type: String
@@ -44,41 +44,41 @@ Parameters:
     Type: String
     Default: 172.16.22.0/24
 
-  NatGateway: 
+  NatGateway:
     Description: Create NatGateway (Yes or No)?
     Default: "Yes"
     Type: String
-    AllowedValues: 
+    AllowedValues:
       - "Yes"
 
-  # Amazon OpenSearch Variables
+  ######## Amazon OpenSearch Variables ########
   DomainName:
     Type: String
     Default: "observability-aos"
-  
+
   EngineVersion:
     Description: Amazon OpenSearch Service - Version
     Type: String
     Default: "OpenSearch_1.3"
-  
+
   InstanceType:
     Description: Amazon OpenSearch Service - Instance Type
     Type: String
     Default: "r6g.large.search"
-  
+
   OpenSearchMasterUserName:
     Description: Amazon OpenSearch Service - Username
     Default: "aosadmin"
     Type: String
-  
-  # Reverse Proxy Variables
+
+  ######## Reverse Proxy Variables ########
   ReverseProxyInstanceType:
-   Description: Reverse Proxy EC2 instance type
-   Type: String
-   Default: t2.small
-   AllowedValues:
-    - t2.micro
-    - t2.small
+    Description: Reverse Proxy EC2 instance type
+    Type: String
+    Default: t2.small
+    AllowedValues:
+      - t2.micro
+      - t2.small
 
   ReverseProxySSHLocation:
     Description: Allow SSH into Proxy instance
@@ -86,8 +86,8 @@ Parameters:
     Default: 172.16.0.0/16
     AllowedPattern: '(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})/(\d{1,2})'
     ConstraintDescription: must be a valid IP CIDR range of the form x.x.x.x/x.
-  
-  # Cloud9 Variables
+
+  ######## Cloud9 Variables ########
   EnvironmentNameC9:
     Description: An environment name that is prefixed to resource names
     Type: String
@@ -102,32 +102,32 @@ Parameters:
       - t3.small
       - t3.medium
     ConstraintDescription: Must be a valid Cloud9 instance type
-  C9EnvType: 
+  C9EnvType:
     Description: Environment type.
     Default: self
     Type: String
-    AllowedValues: 
+    AllowedValues:
       - self
       - 3rdParty
       - event-engine
       - workshop-studio
     ConstraintDescription: must specify self or 3rdParty.
-  OwnerArn: 
+  OwnerArn:
     Type: String
     Description: The Arn of the Cloud9 Owner to be set if 3rdParty deployment.
     Default: ""
-  C9InstanceVolumeSize: 
+  C9InstanceVolumeSize:
     Type: Number
-    Description: The Size in GB of the Cloud9 Instance Volume. 
+    Description: The Size in GB of the Cloud9 Instance Volume.
     Default: 30
-  
-  # EKS Cluster Variables
+
+  ######## EKS Cluster Variables ########
   EKSClusterName:
-    Description: 'Please enter the EKS Cluster Name'
+    Description: "Please enter the EKS Cluster Name"
     Type: String
     Default: "observability-cluster"
 
-  # General
+  ######## General ########
   S3BucketName:
     Description: "Please enter the bucket name for the dependencies CloudFormation templates"
     Type: String
@@ -136,47 +136,46 @@ Parameters:
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
-    - Label:
-        default: "General Information"
-      Parameters:
-      - EnvironmentName
-      - S3BucketName
-    - Label:
-        default: "Network Configuration"
-      Parameters:
-      - VpcCIDR
-      - PublicSubnet1CIDR
-      - PublicSubnet2CIDR
-      - PublicSubnet3CIDR
-      - PrivateSubnet1CIDR
-      - PrivateSubnet2CIDR
-      - PrivateSubnet3CIDR
-      - NatGateway
-    - Label:
-        default: "OpenSearch Configuration"
-      Parameters:
-      - DomainName
-      - EngineVersion
-      - InstanceType
-      - OpenSearchMasterUserName
-    - Label:
-        default: "Reverse Proxy Configuration"
-      Parameters:
-      - ReverseProxyInstanceType
-      - ReverseProxySSHLocation
-    - Label:
-        default: "Cloud9 Configuration"
-      Parameters:
-      - EnvironmentNameC9
-      - C9InstanceType
-      - C9EnvType
-      - OwnerArn
-      - C9InstanceVolumeSize
-    - Label:
-        default: "EKS Configuration"
-      Parameters:
-      - EKSClusterName
-
+      - Label:
+          default: "General Information"
+        Parameters:
+          - EnvironmentName
+          - S3BucketName
+      - Label:
+          default: "Network Configuration"
+        Parameters:
+          - VpcCIDR
+          - PublicSubnet1CIDR
+          - PublicSubnet2CIDR
+          - PublicSubnet3CIDR
+          - PrivateSubnet1CIDR
+          - PrivateSubnet2CIDR
+          - PrivateSubnet3CIDR
+          - NatGateway
+      - Label:
+          default: "OpenSearch Configuration"
+        Parameters:
+          - DomainName
+          - EngineVersion
+          - InstanceType
+          - OpenSearchMasterUserName
+      - Label:
+          default: "Reverse Proxy Configuration"
+        Parameters:
+          - ReverseProxyInstanceType
+          - ReverseProxySSHLocation
+      - Label:
+          default: "Cloud9 Configuration"
+        Parameters:
+          - EnvironmentNameC9
+          - C9InstanceType
+          - C9EnvType
+          - OwnerArn
+          - C9InstanceVolumeSize
+      - Label:
+          default: "EKS Configuration"
+        Parameters:
+          - EKSClusterName
 
 Resources:
   Base:
@@ -189,8 +188,8 @@ Resources:
         PublicSubnet1CIDR: !Ref PublicSubnet1CIDR
         PublicSubnet2CIDR: !Ref PublicSubnet2CIDR
         PublicSubnet3CIDR: !Ref PublicSubnet3CIDR
-        PrivateSubnet1CIDR: !Ref PrivateSubnet1CIDR 
-        PrivateSubnet2CIDR: !Ref PrivateSubnet2CIDR 
+        PrivateSubnet1CIDR: !Ref PrivateSubnet1CIDR
+        PrivateSubnet2CIDR: !Ref PrivateSubnet2CIDR
         PrivateSubnet3CIDR: !Ref PrivateSubnet3CIDR
         NatGateway: !Ref NatGateway
 
@@ -240,5 +239,5 @@ Resources:
         VPC: !GetAtt Base.Outputs.VPC
         PublicSubnet1: !GetAtt Base.Outputs.PublicSubnet1
         PublicSubnet2: !GetAtt Base.Outputs.PublicSubnet2
-        PrivateSubnet1: !GetAtt Base.Outputs.PrivateSubnet1 
+        PrivateSubnet1: !GetAtt Base.Outputs.PrivateSubnet1
         PrivateSubnet2: !GetAtt Base.Outputs.PrivateSubnet2

--- a/cf-templates/opensearch.yaml
+++ b/cf-templates/opensearch.yaml
@@ -368,7 +368,7 @@ Resources:
           CidrIp: 0.0.0.0/0
       VpcId: !Ref VPC
 
-  ################## Lambda Get PublicIP Information ###################
+  ######## Lambda Get PublicIP Information ########
   GetEC2PublicIP:
     Type: AWS::Lambda::Function
     DependsOn: ReverseProxyLaunchConfig

--- a/cf-templates/opensearch.yaml
+++ b/cf-templates/opensearch.yaml
@@ -1,7 +1,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: "This template creates the OpenSearch Service Domain and OpenSearch dependencies for the Observability with Amazon workshop"
 
-Parameters: 
+Parameters:
   DomainName:
     Type: String
   EngineVersion:
@@ -57,12 +57,7 @@ Mappings:
     sa-east-1:
       HVM64: ami-00d10ca79f70a302a
 
-Resources: 
-  AWSServiceRoleForAmazonOpenSearchService:
-    Type: 'AWS::IAM::ServiceLinkedRole'
-    Properties:
-      AWSServiceName: opensearchservice.amazonaws.com
-
+Resources:
   OpenSearchIngressSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
@@ -70,9 +65,9 @@ Resources:
       GroupDescription: "Security group for opensearch ingress rule"
       VpcId: !Ref VPC
       SecurityGroupIngress:
-        - FromPort: '443'
+        - FromPort: "443"
           IpProtocol: tcp
-          ToPort: '443'
+          ToPort: "443"
           CidrIp: 0.0.0.0/0
       SecurityGroupEgress:
         - Description: Allow all outbound traffic
@@ -80,17 +75,16 @@ Resources:
           CidrIp: 0.0.0.0/0
 
   OpenSearchServiceDomain:
-    Type: 'AWS::OpenSearchService::Domain'
-    DependsOn: 
+    Type: "AWS::OpenSearchService::Domain"
+    DependsOn:
       - OpenSearchIngressSecurityGroup
-      - AWSServiceRoleForAmazonOpenSearchService
     Properties:
       DomainName:
         Ref: DomainName
       EngineVersion:
         Ref: EngineVersion
       ClusterConfig:
-        InstanceCount: '1'
+        InstanceCount: "1"
         InstanceType:
           Ref: InstanceType
       DomainEndpointOptions:
@@ -101,17 +95,17 @@ Resources:
         Enabled: true
       EBSOptions:
         EBSEnabled: true
-        Iops: '0'
-        VolumeSize: '100'
-        VolumeType: 'gp2'
+        Iops: "0"
+        VolumeSize: "100"
+        VolumeType: "gp2"
       AccessPolicies:
-        Version: '2012-10-17'
+        Version: "2012-10-17"
         Statement:
           - Effect: Allow
             Principal:
-              AWS: '*'
-            Action: 'es:*'
-            Resource: '*'
+              AWS: "*"
+            Action: "es:*"
+            Resource: "*"
       AdvancedOptions:
         rest.action.multi.allow_explicit_index: true
       AdvancedSecurityOptions:
@@ -120,10 +114,10 @@ Resources:
         MasterUserOptions:
           MasterUserName: !Ref OpenSearchMasterUserName
           MasterUserPassword: !Join
-                                - ""
-                                - - "{{resolve:secretsmanager:"
-                                  - !Ref AOSMasterPasswordSecret
-                                  - ":SecretString:password}}"
+            - ""
+            - - "{{resolve:secretsmanager:"
+              - !Ref AOSMasterPasswordSecret
+              - ":SecretString:password}}"
       VPCOptions:
         SubnetIds:
           - !Ref PrivateSubnet1
@@ -132,49 +126,50 @@ Resources:
     UpdatePolicy:
       EnableVersionUpgrade: true
 
-################## GENERATE OPENSEARCH PASSWORD ###################
+  ################## GENERATE OPENSEARCH PASSWORD ###################
   AOSMasterPasswordSecret:
     Type: AWS::SecretsManager::Secret
     Properties:
       Description: This secret has a dynamically generated secret password.
       GenerateSecretString:
-        SecretStringTemplate: !Join [ '', [ '{"username": "', !Ref OpenSearchMasterUserName, '"}' ] ]
+        SecretStringTemplate:
+          !Join ["", ['{"username": "', !Ref OpenSearchMasterUserName, '"}']]
         GenerateStringKey: "password"
         PasswordLength: 10
         ExcludeCharacters: "\" ' ( ) * + , - . / : ; < = > ! # ? @ [ \\ ] ^ _ ` { | } ~"
 
-  RetrieveAOSPasswordLambdaPolicy: 
+  RetrieveAOSPasswordLambdaPolicy:
     Type: AWS::IAM::ManagedPolicy
-    Properties: 
-      PolicyDocument: 
+    Properties:
+      PolicyDocument:
         Version: 2012-10-17
-        Statement: 
-          - Action: 
+        Statement:
+          - Action:
               - logs:CreateLogGroup
               - logs:CreateLogStream
               - logs:PutLogEvents
             Effect: Allow
             Resource: arn:aws:logs:*:*:*
             Sid: AllowCWLogsWrite
-          - Action: 
+          - Action:
               - secretsmanager:GetSecretValue
             Effect: Allow
             Resource: !Ref AOSMasterPasswordSecret
-    
-  RetrieveAOSPasswordLambdaExecutionRole: 
+
+  RetrieveAOSPasswordLambdaExecutionRole:
     Type: AWS::IAM::Role
     DependsOn: RetrieveAOSPasswordLambdaPolicy
     Properties:
-      AssumeRolePolicyDocument: 
+      AssumeRolePolicyDocument:
         Version: 2012-10-17
-        Statement: 
-          - Action: 
+        Statement:
+          - Action:
               - sts:AssumeRole
             Effect: Allow
-            Principal: 
-              Service: 
+            Principal:
+              Service:
                 - lambda.amazonaws.com
-      ManagedPolicyArns: 
+      ManagedPolicyArns:
         - !Ref RetrieveAOSPasswordLambdaPolicy
       Path: /
 
@@ -241,8 +236,8 @@ Resources:
     Type: Custom::RetrieveAOSPassword
     DependsOn: RetrieveAOSPasswordLambdaFunction
     Properties:
-        ServiceToken:
-            Fn::GetAtt: RetrieveAOSPasswordLambdaFunction.Arn
+      ServiceToken:
+        Fn::GetAtt: RetrieveAOSPasswordLambdaFunction.Arn
 
   ######## Reverse Proxy Template ########
   IAMRole:
@@ -250,7 +245,7 @@ Resources:
     Properties:
       RoleName: !Sub Linux-SSMRoletoEC2-${AWS::StackName}
       AssumeRolePolicyDocument:
-        Version: '2012-10-17'
+        Version: "2012-10-17"
         Statement:
           - Effect: Allow
             Principal:
@@ -265,38 +260,37 @@ Resources:
     Properties:
       Path: "/"
       Roles:
-        - 
-          Ref: IAMRole
+        - Ref: IAMRole
 
   ReverseProxyASG:
-    Type: 'AWS::AutoScaling::AutoScalingGroup'
+    Type: "AWS::AutoScaling::AutoScalingGroup"
     Properties:
       VPCZoneIdentifier:
         - !Ref PublicSubnet1
         - !Ref PublicSubnet2
       LaunchConfigurationName: !Ref ReverseProxyLaunchConfig
-      MinSize: '1'
-      MaxSize: '1'
+      MinSize: "1"
+      MaxSize: "1"
       Tags:
         - Key: Environment
           Value: Poc
           PropagateAtLaunch: "true"
         - Key: IsUsedForDeploy
           Value: True
-          PropagateAtLaunch: "true"  
+          PropagateAtLaunch: "true"
         - Key: Name
           Value: ProxyInstance
           PropagateAtLaunch: "true"
 
   ReverseProxyLaunchConfig:
-    Type: 'AWS::AutoScaling::LaunchConfiguration'
+    Type: "AWS::AutoScaling::LaunchConfiguration"
     Properties:
       AssociatePublicIpAddress: True
       IamInstanceProfile: !Ref InstanceProfile
-      ImageId: !FindInMap 
+      ImageId: !FindInMap
         - AWSRegionArch2AMI
-        - !Ref 'AWS::Region'
-        - !FindInMap 
+        - !Ref "AWS::Region"
+        - !FindInMap
           - AWSInstanceType2Arch
           - !Ref ReverseProxyInstanceType
           - Arch
@@ -307,7 +301,7 @@ Resources:
           yum install jq -y
           amazon-linux-extras install nginx1.12
           openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/nginx/cert.key -out /etc/nginx/cert.crt -subj /C=US/ST=./L=./O=./CN=.\n
-          
+
           cat << EOF > /etc/nginx/conf.d/nginx_opensearch.conf
           server {
               listen 443;
@@ -349,24 +343,24 @@ Resources:
           systemctl enable nginx.service
       SecurityGroups:
         - !Ref ReverseProxyInstanceSecurityGroup
-      InstanceType: !Ref ReverseProxyInstanceType 
+      InstanceType: !Ref ReverseProxyInstanceType
 
   ReverseProxyInstanceSecurityGroup:
-    Type: 'AWS::EC2::SecurityGroup'
+    Type: "AWS::EC2::SecurityGroup"
     Properties:
       GroupDescription: Enable SSH access
       SecurityGroupIngress:
         - IpProtocol: tcp
-          FromPort: '22'
-          ToPort: '22'
+          FromPort: "22"
+          ToPort: "22"
           CidrIp: !Ref ReverseProxySSHLocation
         - IpProtocol: tcp
-          FromPort: '443'
-          ToPort: '443'
+          FromPort: "443"
+          ToPort: "443"
           CidrIp: !Ref ReverseProxySSHLocation
         - IpProtocol: tcp
-          FromPort: '443'
-          ToPort: '443'
+          FromPort: "443"
+          ToPort: "443"
           CidrIp: 0.0.0.0/0
       SecurityGroupEgress:
         - Description: Allow all outbound traffic
@@ -374,88 +368,88 @@ Resources:
           CidrIp: 0.0.0.0/0
       VpcId: !Ref VPC
 
-## Lambda Get PublicIP Information
+  ## Lambda Get PublicIP Information
   GetEC2PublicIP:
-      Type: AWS::Lambda::Function
-      DependsOn: ReverseProxyLaunchConfig
-      Properties:
-        Code:
-          ZipFile: |
-            import json
-            import boto3
-            import logging
-            import urllib3
-            import time
-            http = urllib3.PoolManager()
+    Type: AWS::Lambda::Function
+    DependsOn: ReverseProxyLaunchConfig
+    Properties:
+      Code:
+        ZipFile: |
+          import json
+          import boto3
+          import logging
+          import urllib3
+          import time
+          http = urllib3.PoolManager()
 
-            logger = logging.getLogger(__name__)
-            logging.getLogger().setLevel(logging.INFO)
+          logger = logging.getLogger(__name__)
+          logging.getLogger().setLevel(logging.INFO)
 
-            SUCCESS = "SUCCESS"
-            FAILED = "FAILED"
-            time.sleep(15)
+          SUCCESS = "SUCCESS"
+          FAILED = "FAILED"
+          time.sleep(15)
 
-            def lambda_handler(event, context):
-                global arn
-                logger.info('Event: %s' % json.dumps(event))
-                responseData={}
-                try:
-                    if event['RequestType'] == 'Create' or event['RequestType'] == 'Update':
-                        print("Request Type:",event['RequestType'])
-                        GetPublicIP=event['ResourceProperties']['GetPublicIP']
-                        client = boto3.client('ec2')
-                        response = client.describe_instances(
-                            Filters=[ {
-                                    'Name': 'tag:IsUsedForDeploy',
-                                    'Values': ['true']}
-                            ]
-                        )
-                        for r in response['Reservations']:
-                            for i in r['Instances']:
-                                PublicIpAddress = (i['PublicIpAddress'])
-                                print (PublicIpAddress)
+          def lambda_handler(event, context):
+              global arn
+              logger.info('Event: %s' % json.dumps(event))
+              responseData={}
+              try:
+                  if event['RequestType'] == 'Create' or event['RequestType'] == 'Update':
+                      print("Request Type:",event['RequestType'])
+                      GetPublicIP=event['ResourceProperties']['GetPublicIP']
+                      client = boto3.client('ec2')
+                      response = client.describe_instances(
+                          Filters=[ {
+                                  'Name': 'tag:IsUsedForDeploy',
+                                  'Values': ['true']}
+                          ]
+                      )
+                      for r in response['Reservations']:
+                          for i in r['Instances']:
+                              PublicIpAddress = (i['PublicIpAddress'])
+                              print (PublicIpAddress)
 
-                        responseData={'PublicIpAddress':PublicIpAddress}
-                        print("Sending CFN")
-                    responseStatus = 'SUCCESS'
-                except Exception as e:
-                    print('Failed to process:', e)
-                    responseStatus = 'FAILURE'
-                    responseData = {'Failure': 'Check Logs.'}
-                send(event, context, responseStatus, responseData)
+                      responseData={'PublicIpAddress':PublicIpAddress}
+                      print("Sending CFN")
+                  responseStatus = 'SUCCESS'
+              except Exception as e:
+                  print('Failed to process:', e)
+                  responseStatus = 'FAILURE'
+                  responseData = {'Failure': 'Check Logs.'}
+              send(event, context, responseStatus, responseData)
 
-            def send(event, context, responseStatus, responseData, physicalResourceId=None, noEcho=False):
-                responseUrl = event['ResponseURL']
-                print(responseUrl)
-                responseBody = {'Status': responseStatus,
-                                'Reason': 'See the details in CloudWatch Log Stream: ' + context.log_stream_name,
-                                'PhysicalResourceId': physicalResourceId or context.log_stream_name,
-                                'StackId': event['StackId'],
-                                'RequestId': event['RequestId'],
-                                'LogicalResourceId': event['LogicalResourceId'],
-                                'Data': responseData}
-                json_responseBody = json.dumps(responseBody)
-                print("Response body:\n" + json_responseBody)
-                headers = {
-                    'content-type' : '',
-                    'content-length' : str(len(json_responseBody))
-                }
-                try:
-                    response = http.request('PUT', responseUrl, headers=headers, body=json_responseBody)
-                    print("Status code:", response.status)
-                except Exception as e:
-                    print("send(..) failed executing http.request(..):", e)
-        FunctionName: 'EC2ASG-GetPublicIpAddress'
-        Handler: "index.lambda_handler"
-        Timeout: 30
-        Role: !GetAtt 'LambdaRole.Arn'
-        Runtime: python3.9
+          def send(event, context, responseStatus, responseData, physicalResourceId=None, noEcho=False):
+              responseUrl = event['ResponseURL']
+              print(responseUrl)
+              responseBody = {'Status': responseStatus,
+                              'Reason': 'See the details in CloudWatch Log Stream: ' + context.log_stream_name,
+                              'PhysicalResourceId': physicalResourceId or context.log_stream_name,
+                              'StackId': event['StackId'],
+                              'RequestId': event['RequestId'],
+                              'LogicalResourceId': event['LogicalResourceId'],
+                              'Data': responseData}
+              json_responseBody = json.dumps(responseBody)
+              print("Response body:\n" + json_responseBody)
+              headers = {
+                  'content-type' : '',
+                  'content-length' : str(len(json_responseBody))
+              }
+              try:
+                  response = http.request('PUT', responseUrl, headers=headers, body=json_responseBody)
+                  print("Status code:", response.status)
+              except Exception as e:
+                  print("send(..) failed executing http.request(..):", e)
+      FunctionName: "EC2ASG-GetPublicIpAddress"
+      Handler: "index.lambda_handler"
+      Timeout: 30
+      Role: !GetAtt "LambdaRole.Arn"
+      Runtime: python3.9
   Lambdatrigger:
-     Type: 'Custom::GetEC2PublicIP'
-     DependsOn: ReverseProxyASG
-     Properties:
-       ServiceToken: !GetAtt 'GetEC2PublicIP.Arn'
-       GetPublicIP: !Ref GetEC2PublicIP
+    Type: "Custom::GetEC2PublicIP"
+    DependsOn: ReverseProxyASG
+    Properties:
+      ServiceToken: !GetAtt "GetEC2PublicIP.Arn"
+      GetPublicIP: !Ref GetEC2PublicIP
   LambdaRole:
     Type: AWS::IAM::Role
     Metadata:
@@ -469,8 +463,7 @@ Resources:
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:
-          -
-            Effect: Allow
+          - Effect: Allow
             Principal:
               Service:
                 - lambda.amazonaws.com
@@ -480,13 +473,13 @@ Resources:
       Policies:
         - PolicyName: "lambda-logs"
           PolicyDocument:
-            Version: '2012-10-17'
+            Version: "2012-10-17"
             Statement:
               - Effect: Allow
                 Action:
-                  - 'ec2:Describe*'
-                  - 'ec2:List*'
-                Resource: '*'
+                  - "ec2:Describe*"
+                  - "ec2:List*"
+                Resource: "*"
               - Effect: Allow
                 Action:
                   - logs:CreateLogGroup
@@ -498,14 +491,14 @@ Resources:
 Outputs:
   AOSDomainArn:
     Value:
-      'Fn::GetAtt':
+      "Fn::GetAtt":
         - OpenSearchServiceDomain
         - Arn
     Export:
       Name: AOSDomainArn
   AOSDomainEndpoint:
     Value:
-      'Fn::GetAtt':
+      "Fn::GetAtt":
         - OpenSearchServiceDomain
         - DomainEndpoint
     Export:
@@ -522,9 +515,9 @@ Outputs:
     Description: Proxy (Public IP) for Amazon Opensearch Dashboards
     Value:
       Fn::Join:
-      - ''
-      - - https://
-        - !GetAtt Lambdatrigger.PublicIpAddress
-        - /_dashboards
+        - ""
+        - - https://
+          - !GetAtt Lambdatrigger.PublicIpAddress
+          - /_dashboards
     Export:
       Name: AOSDashboardsPublicIP

--- a/cf-templates/opensearch.yaml
+++ b/cf-templates/opensearch.yaml
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: 2010-09-09
-Description: "This template creates the OpenSearch Service Domain and OpenSearch dependencies for the Observability with Amazon workshop"
+Description: "This template create the Amazon OpenSearch Service Domain resources for the Microservice Observability with Amazon OpenSearch Service Workshop."
 
 Parameters:
   DomainName:
@@ -368,7 +368,7 @@ Resources:
           CidrIp: 0.0.0.0/0
       VpcId: !Ref VPC
 
-  ## Lambda Get PublicIP Information
+  ################## Lambda Get PublicIP Information ###################
   GetEC2PublicIP:
     Type: AWS::Lambda::Function
     DependsOn: ReverseProxyLaunchConfig


### PR DESCRIPTION
This PR aims to fix a problem in creating the Amazon OpenSearch Service in accounts that have not previously created the role 'AWSServiceRoleForAmazonOpenSearchService'. It was moved to base stack because even creating depends On the error of missing role in the nested stack is not avoided.

Added new permissions for the role that is attached to the Lambda custom resource and creates and deletes the Amazon EKS cluster.

Minor fixes to template descriptions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
