### PR TITLE
Fix/decoupling Output configuration for main stack and AMI removal

### DIFF
--- a/cf-templates/main.yaml
+++ b/cf-templates/main.yaml
@@ -255,5 +255,5 @@ Outputs:
     Value: !GetAtt OpenSearch.Outputs.AOSDomainPassword 
   StackRef:
     Value: !Ref Cloud9
-  AOSDomainEndpoint0:
+  Cloud9IDE0:
     Value: !GetAtt Cloud9.Outputs.Cloud9IDE

--- a/cf-templates/main.yaml
+++ b/cf-templates/main.yaml
@@ -252,7 +252,7 @@ Outputs:
   AOSDomainUserName0:
     Value: !GetAtt OpenSearch.Outputs.AOSDomainUserName
   AOSDomainPassword0:
-    Value: !GetAtt OpenSearch.Outputs.AOSDomainPassword
+    Value: !GetAtt OpenSearch.Outputs.AOSDomainPassword 
   StackRef2:
     Value: !Ref Cloud9
   Cloud9IDE0:

--- a/cf-templates/main.yaml
+++ b/cf-templates/main.yaml
@@ -241,3 +241,19 @@ Resources:
         PublicSubnet2: !GetAtt Base.Outputs.PublicSubnet2
         PrivateSubnet1: !GetAtt Base.Outputs.PrivateSubnet1
         PrivateSubnet2: !GetAtt Base.Outputs.PrivateSubnet2
+        
+Outputs:
+  StackRef:
+    Value: !Ref OpenSearch
+  AOSDashboardsPublic0:
+    Value: !GetAtt OpenSearch.Outputs.AOSDashboardsPublicIP
+  AOSDomainEndpoint0:
+    Value: !GetAtt OpenSearch.Outputs.AOSDomainEndpoint
+  AOSDomainUserName0:
+    Value: !GetAtt OpenSearch.Outputs.AOSDomainUserName
+  AOSDomainPassword0:
+    Value: !GetAtt OpenSearch.Outputs.AOSDomainPassword 
+  StackRef:
+    Value: !Ref Cloud9
+  AOSDomainEndpoint0:
+    Value: !GetAtt Cloud9.Outputs.Cloud9IDE

--- a/cf-templates/main.yaml
+++ b/cf-templates/main.yaml
@@ -245,15 +245,15 @@ Resources:
 Outputs:
   StackRef1:
     Value: !Ref OpenSearch
-  AOSDashboardsPublicOutpt:
+  AOSDashboardsPublicOut:
     Value: !GetAtt OpenSearch.Outputs.AOSDashboardsPublicIP
-  AOSDomainEndpointOutpt:
+  AOSDomainEndpointOut:
     Value: !GetAtt OpenSearch.Outputs.AOSDomainEndpoint
-  AOSDomainUserNameOutpt:
+  AOSDomainUserNameOut:
     Value: !GetAtt OpenSearch.Outputs.AOSDomainUserName
-  AOSDomainPasswordOutpt:
+  AOSDomainPasswordOut:
     Value: !GetAtt OpenSearch.Outputs.AOSDomainPassword
   StackRef2:
     Value: !Ref Cloud9
-  Cloud9IDEOutpt:
+  Cloud9IDEOut:
     Value: !GetAtt Cloud9.Outputs.Cloud9IDE

--- a/cf-templates/main.yaml
+++ b/cf-templates/main.yaml
@@ -241,19 +241,19 @@ Resources:
         PublicSubnet2: !GetAtt Base.Outputs.PublicSubnet2
         PrivateSubnet1: !GetAtt Base.Outputs.PrivateSubnet1
         PrivateSubnet2: !GetAtt Base.Outputs.PrivateSubnet2
-        
+
 Outputs:
-  StackRef:
+  StackRef1:
     Value: !Ref OpenSearch
-  AOSDashboardsPublic0:
+  AOSDashboardsPublicOutpt:
     Value: !GetAtt OpenSearch.Outputs.AOSDashboardsPublicIP
-  AOSDomainEndpoint0:
+  AOSDomainEndpointOutpt:
     Value: !GetAtt OpenSearch.Outputs.AOSDomainEndpoint
-  AOSDomainUserName0:
+  AOSDomainUserNameOutpt:
     Value: !GetAtt OpenSearch.Outputs.AOSDomainUserName
-  AOSDomainPassword0:
-    Value: !GetAtt OpenSearch.Outputs.AOSDomainPassword 
-  StackRef:
+  AOSDomainPasswordOutpt:
+    Value: !GetAtt OpenSearch.Outputs.AOSDomainPassword
+  StackRef2:
     Value: !Ref Cloud9
-  Cloud9IDE0:
+  Cloud9IDEOutpt:
     Value: !GetAtt Cloud9.Outputs.Cloud9IDE

--- a/cf-templates/main.yaml
+++ b/cf-templates/main.yaml
@@ -245,15 +245,15 @@ Resources:
 Outputs:
   StackRef1:
     Value: !Ref OpenSearch
-  AOSDashboardsPublicOut:
+  AOSDashboardsPublic0:
     Value: !GetAtt OpenSearch.Outputs.AOSDashboardsPublicIP
-  AOSDomainEndpointOut:
+  AOSDomainEndpoint0:
     Value: !GetAtt OpenSearch.Outputs.AOSDomainEndpoint
-  AOSDomainUserNameOut:
+  AOSDomainUserName0:
     Value: !GetAtt OpenSearch.Outputs.AOSDomainUserName
-  AOSDomainPasswordOut:
+  AOSDomainPassword0:
     Value: !GetAtt OpenSearch.Outputs.AOSDomainPassword
   StackRef2:
     Value: !Ref Cloud9
-  Cloud9IDEOut:
+  Cloud9IDE0:
     Value: !GetAtt Cloud9.Outputs.Cloud9IDE

--- a/cf-templates/opensearch.yaml
+++ b/cf-templates/opensearch.yaml
@@ -50,8 +50,6 @@ Mappings:
       HVM64: ami-03ededff12e34e59e
     us-east-2:
       HVM64: ami-0c7478fd229861c57
-    us-west-1:
-      HVM64: ami-06542a822d33e2e40
     us-west-2:
       HVM64: ami-0b36cd6786bcfe120
     sa-east-1:


### PR DESCRIPTION
Output configuration for the main stack that was only exposed on child stacks before. Removed AMI for us-west-1 region as it only has two AZ`s.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
