### PR TITLE
Added new parameter for Cloud9

### DIFF
--- a/cf-templates/cloud9.yaml
+++ b/cf-templates/cloud9.yaml
@@ -398,6 +398,7 @@ Resources:
     Type: AWS::Cloud9::EnvironmentEC2
     Properties:
       Description: !Sub AWS Cloud9 instance for ${EnvironmentNameC9}
+      ImageId: amazonlinux-2023-x86_64
       SubnetId: !Ref PublicSubnet1
       #ConnectionType: CONNECT_SSM
 


### PR DESCRIPTION
Due to the new Cloud9 parameter, it was generating a failure when executing the CFN.
